### PR TITLE
优化长按倍速行为

### DIFF
--- a/app/src/main/java/com/a10miaomiao/bilimiao/widget/player/DanmakuVideoPlayer.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/widget/player/DanmakuVideoPlayer.kt
@@ -350,11 +350,13 @@ class DanmakuVideoPlayer : StandardGSYVideoPlayer {
     // start 长按倍速播放
     private var touchSurfaceDownTime = Long.MAX_VALUE
     private var isSpeedPlaying = false
+    private var lastSpeed = 0f  // init an invalid value
     private val longClickControlTask = Runnable {
         if (System.currentTimeMillis() - touchSurfaceDownTime >= 500
             && mCurrentState == CURRENT_STATE_PLAYING
             && !mChangePosition && !mChangeVolume && !mBrightness) {
             isSpeedPlaying = true
+            lastSpeed = speed
             speed = 2f
             mSpeedTips.visibility = View.VISIBLE
             mTouchingProgressBar = false
@@ -381,7 +383,7 @@ class DanmakuVideoPlayer : StandardGSYVideoPlayer {
         if (isSpeedPlaying) {
             mSpeedTips.visibility = View.GONE
             isSpeedPlaying = false
-            speed = 1f
+            speed = lastSpeed
             (mSpeedTipsIV.drawable as? AnimationDrawable)?.stop()
         } else {
             super.touchSurfaceUp()

--- a/app/src/main/java/com/a10miaomiao/bilimiao/widget/player/DanmakuVideoPlayer.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/widget/player/DanmakuVideoPlayer.kt
@@ -357,7 +357,7 @@ class DanmakuVideoPlayer : StandardGSYVideoPlayer {
             && !mChangePosition && !mChangeVolume && !mBrightness) {
             isSpeedPlaying = true
             lastSpeed = speed
-            speed = 2f
+            speed *= 2
             mSpeedTips.visibility = View.VISIBLE
             mTouchingProgressBar = false
             (mSpeedTipsIV.drawable as? AnimationDrawable)?.start()

--- a/app/src/main/res/layout/layout_danmaku_palyer.xml
+++ b/app/src/main/res/layout/layout_danmaku_palyer.xml
@@ -412,7 +412,7 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="2倍速播放中"
+            android:text="倍速播放中"
             android:textColor="@color/white"/>
     </LinearLayout>
 


### PR DESCRIPTION
1. 记忆倍速播放之前的速度，避免倍速恢复后反而减速
2. 速播放改为现有速度*2
    这样 3 倍速下就是 6 倍速而不是反向减速
    这里的 3 倍速考虑直接乘 2 而不是乘以 1.5
    之类的是因为 3 倍速已经很快了，
    但是还需要倍速可能是因为视频废话过多