### PR TITLE
修复二级评论只加载两页

### DIFF
--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/video/comment/VideoCommentDetailViewModel.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/video/comment/VideoCommentDetailViewModel.kt
@@ -74,7 +74,6 @@ class VideoCommentDetailViewModel(
                 scene = ReplyOuterClass.DetailListScene.REPLY
                 _cursor?.let {
                     cursor = ReplyOuterClass.CursorReq.newBuilder()
-                        .setPrev(it.prev)
                         .setNext(it.next)
                         .setMode(it.mode)
                         .build()


### PR DESCRIPTION
原本二级评论只能加载40条，把这行删了就好了