### PR TITLE
修改页面标题的刷新逻辑

### DIFF
--- a/app/src/main/java/com/a10miaomiao/bilimiao/MainActivity.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/MainActivity.kt
@@ -302,26 +302,16 @@ class MainActivity
     }
 
     fun notifyFocusChanged() {
-        if (currentNav.childFragmentManager.fragments.isNotEmpty()) {
-            val fragment = currentNav.childFragmentManager.fragments.last()
-            ui.mAppBar.canBack =
-                currentNav.navController.currentDestination?.id != MainNavGraph.dest.main
-            ui.mAppBar.showPointer = ui.root.subContentShown
-            ui.mAppBar.pointerOrientation = ui.root.pointerExchanged
-
-            if (fragment is MyPage) {
-                fragment.pageConfig.notifyConfigChanged()
-            }
-        }
+        ui.mAppBar.canBack =
+            currentNav.navController.currentDestination?.id != MainNavGraph.dest.main
+        ui.mAppBar.showPointer = ui.root.subContentShown
+        ui.mAppBar.pointerOrientation = ui.root.pointerExchanged
+        notifyConfigChanged()
     }
-    fun notifyConfigChanged(config: MyPageConfigInfo){
-        currentNav.childFragmentManager.fragments.let {
-            if(it.isNotEmpty()){
-                it.last().let{
-                    if(it is MyPage){
-                        setMyPageConfig(it.pageConfig.configInfo)
-                    }
-                }
+    fun notifyConfigChanged(){
+        currentNav.childFragmentManager.fragments.lastOrNull().let {
+            if(it is MyPage){
+                setMyPageConfig(it.pageConfig.configInfo)
             }
         }
     }

--- a/app/src/main/java/com/a10miaomiao/bilimiao/comm/delegate/sheet/BottomSheetDelegate.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/comm/delegate/sheet/BottomSheetDelegate.kt
@@ -104,7 +104,14 @@ class BottomSheetDelegate(
     override fun onAttachFragment(fragmentManager: FragmentManager, fragment: Fragment) {
         if (fragment is MyPage) {
             val config = fragment.pageConfig
-            config.setConfig = this::setMyPageConfig
+            config.setConfig = this::notifyConfigChanged
+        }
+    }
+    private fun notifyConfigChanged(){
+        navBottomSheetFragment.childFragmentManager.fragments.lastOrNull().let {
+            if(it is MyPage){
+                setMyPageConfig(it.pageConfig.configInfo)
+            }
         }
     }
 

--- a/bilimiao-comm/src/main/java/com/a10miaomiao/bilimiao/comm/mypage/MyPageConfig.kt
+++ b/bilimiao-comm/src/main/java/com/a10miaomiao/bilimiao/comm/mypage/MyPageConfig.kt
@@ -12,7 +12,7 @@ class MyPageConfig(
 
     var setConfig: ((MyPageConfigInfo) -> Unit)? = null
 
-    private val configInfo get() = getConfigInfo()
+    val configInfo get() = getConfigInfo()
 
     private val lifecycleObserver = object : DefaultLifecycleObserver {
         override fun onStart(owner: LifecycleOwner) {

--- a/bilimiao-comm/src/main/java/com/a10miaomiao/bilimiao/comm/mypage/MyPageConfig.kt
+++ b/bilimiao-comm/src/main/java/com/a10miaomiao/bilimiao/comm/mypage/MyPageConfig.kt
@@ -10,7 +10,7 @@ class MyPageConfig(
     private val getConfigInfo: (() -> MyPageConfigInfo),
 ) {
 
-    var setConfig: ((MyPageConfigInfo) -> Unit)? = null
+    var setConfig: (() -> Unit)? = null
 
     val configInfo get() = getConfigInfo()
 
@@ -41,7 +41,7 @@ class MyPageConfig(
     fun notifyConfigChanged () {
         if (fragment.lifecycle.currentState == Lifecycle.State.RESUMED) {
             setConfig?.let {
-                it(configInfo)
+                it()
             }
         }
     }


### PR DESCRIPTION
分屏的时候，可以防止不在焦点的页面覆盖标题了。
但是这样和底部弹出页面的逻辑不对称了，多出了一个无用参数