### PR TITLE
调整分屏页面跳转

### DIFF
--- a/app/src/main/java/com/a10miaomiao/bilimiao/comm/BiliJsBridge.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/comm/BiliJsBridge.kt
@@ -108,7 +108,7 @@ class BiliJsBridge(
                 val url = event.data["url"].asString ?: return
                 activity.runOnUiThread {
                     val re = BiliNavigation.navigationTo(
-                        webView,
+                        NavHosts.pointerNavController,
                         url
                     )
                     if (!re) {

--- a/app/src/main/java/com/a10miaomiao/bilimiao/comm/BiliNavigation.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/comm/BiliNavigation.kt
@@ -13,13 +13,10 @@ import androidx.navigation.NavOptions
 import androidx.navigation.Navigation
 import androidx.navigation.findNavController
 import cn.a10miaomiao.bilimiao.compose.pages.bangumi.BangumiDetailPage
-import com.a10miaomiao.bilimiao.MainActivity
 import com.a10miaomiao.bilimiao.R
 import com.a10miaomiao.bilimiao.comm.navigation.MainNavArgs
 import com.a10miaomiao.bilimiao.comm.navigation.navigateToCompose
-import com.a10miaomiao.bilimiao.comm.utils.BiliUrlMatcher
 import com.a10miaomiao.bilimiao.comm.utils.DebugMiao
-import com.a10miaomiao.bilimiao.page.bangumi.BangumiDetailFragment
 import com.a10miaomiao.bilimiao.page.user.UserFragment
 import com.a10miaomiao.bilimiao.page.video.VideoInfoFragment
 import com.a10miaomiao.bilimiao.page.web.WebFragment
@@ -132,7 +129,7 @@ object BiliNavigation {
             || "b23.tv" in host
             || "b23.snm0516.aisee.tv" in host) {
             // b站网页使用内部浏览器打开
-            val nav = (activity as? MainActivity)?.pointerNav?.navController
+            val nav = NavHosts.pointerNavController
                 ?: activity.findNavController(R.id.nav_host_fragment)
             nav.navigate(
                 WebFragment.actionId,

--- a/app/src/main/java/com/a10miaomiao/bilimiao/comm/delegate/sheet/BottomSheetDelegate.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/comm/delegate/sheet/BottomSheetDelegate.kt
@@ -12,7 +12,7 @@ import androidx.navigation.NavDestination
 import androidx.navigation.fragment.NavHostFragment
 import cn.a10miaomiao.bilimiao.compose.ComposeFragment
 import com.a10miaomiao.bilimiao.MainNavGraph
-import com.a10miaomiao.bilimiao.R
+import com.a10miaomiao.bilimiao.comm.NavHosts
 import com.a10miaomiao.bilimiao.comm.mypage.MyPage
 import com.a10miaomiao.bilimiao.comm.mypage.MyPageConfigInfo
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -39,6 +39,8 @@ class BottomSheetDelegate(
         MainNavGraph.createGraph(navBottomSheetController, MainNavGraph.dest.template)
         navBottomSheetController.addOnDestinationChangedListener(this)
         navBottomSheetFragment.childFragmentManager.addFragmentOnAttachListener(this)
+
+        NavHosts.getBottomSheetHostFrag={navBottomSheetFragment}
 
         ui.bottomSheetBehavior?.let { behavior ->
             behavior.isHideable = true

--- a/app/src/main/java/com/a10miaomiao/bilimiao/comm/navigation/NavigationDSL.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/comm/navigation/NavigationDSL.kt
@@ -10,15 +10,8 @@ import androidx.navigation.NavOptions
 import cn.a10miaomiao.bilimiao.compose.ComposeFragment
 import cn.a10miaomiao.bilimiao.compose.base.ComposePage
 import com.a10miaomiao.bilimiao.MainActivity
-import com.a10miaomiao.bilimiao.R
 import com.a10miaomiao.bilimiao.activity.SearchActivity
-import com.a10miaomiao.bilimiao.comm.mypage.SearchConfigInfo
-import com.a10miaomiao.bilimiao.comm.utils.miaoLogger
-import com.a10miaomiao.bilimiao.page.search.SearchStartFragment
-import com.a10miaomiao.bilimiao.page.start.StartFragment
-import com.a10miaomiao.bilimiao.widget.scaffold.ScaffoldView
-import com.a10miaomiao.bilimiao.widget.scaffold.getScaffoldView
-import java.lang.Exception
+import com.a10miaomiao.bilimiao.comm.NavHosts
 
 fun NavController.tryPopBackStack(): Boolean {
     return try {
@@ -34,8 +27,8 @@ fun NavController.navigateToCompose(
     url: String,
     navOptions: NavOptions? = null,
 ) {
-    val curFragment = (context as? MainActivity)
-        ?.getPrimaryNavigationFragment(this)
+    val curFragment = NavHosts.getNavHostFragment(this)
+        ?.childFragmentManager?.primaryNavigationFragment
     if (curFragment is ComposeFragment) {
         val composeNav = curFragment.composeNav
         val arguments = composeNav.currentBackStackEntry?.arguments

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/MainBackPopupMenu.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/MainBackPopupMenu.kt
@@ -5,10 +5,8 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.widget.PopupMenu
-import androidx.navigation.findNavController
-import com.a10miaomiao.bilimiao.MainActivity
 import com.a10miaomiao.bilimiao.MainNavGraph
-import com.a10miaomiao.bilimiao.R
+import com.a10miaomiao.bilimiao.comm.NavHosts
 import com.a10miaomiao.bilimiao.comm.delegate.player.BasePlayerDelegate
 
 class MainBackPopupMenu(
@@ -34,10 +32,8 @@ class MainBackPopupMenu(
     override fun onMenuItemClick(item: MenuItem?): Boolean {
         when (item?.itemId) {
             0 -> {
-                if(activity is MainActivity) {
-                    val nav = activity.currentNav.navController
-                    return nav.popBackStack(MainNavGraph.dest.main, false)
-                }
+                val nav = NavHosts.currentNavController
+                return nav.popBackStack(MainNavGraph.dest.main, false)
             }
             1 -> {
                 basePlayerDelegate.closePlayer()

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/MainFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/MainFragment.kt
@@ -5,55 +5,64 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
 import android.preference.PreferenceManager
-import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
 import android.widget.Space
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AlertDialog
-import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.navigation.findNavController
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
 import cn.a10miaomiao.bilimiao.compose.pages.download.DownloadListPage
-import cn.a10miaomiao.miao.binding.android.view.*
+import cn.a10miaomiao.miao.binding.android.view._height
+import cn.a10miaomiao.miao.binding.android.view._leftPadding
+import cn.a10miaomiao.miao.binding.android.view._rightPadding
+import cn.a10miaomiao.miao.binding.android.view._topPadding
 import cn.a10miaomiao.miao.binding.miaoEffect
-import com.a10miaomiao.bilimiao.MainActivity
 import com.a10miaomiao.bilimiao.R
-import com.a10miaomiao.bilimiao.comm.*
+import com.a10miaomiao.bilimiao.comm.NavHosts
+import com.a10miaomiao.bilimiao.comm.connectStore
 import com.a10miaomiao.bilimiao.comm.delegate.player.BasePlayerDelegate
-import com.a10miaomiao.bilimiao.comm.delegate.theme.ThemeDelegate
+import com.a10miaomiao.bilimiao.comm.diViewModel
 import com.a10miaomiao.bilimiao.comm.dsl.addOnDoubleClickTabListener
-import com.a10miaomiao.bilimiao.comm.mypage.*
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
+import com.a10miaomiao.bilimiao.comm.mypage.MenuItemPropInfo
+import com.a10miaomiao.bilimiao.comm.mypage.MenuKeys
+import com.a10miaomiao.bilimiao.comm.mypage.MyPage
+import com.a10miaomiao.bilimiao.comm.mypage.myMenuItem
+import com.a10miaomiao.bilimiao.comm.mypage.myPageConfig
 import com.a10miaomiao.bilimiao.comm.navigation.FragmentNavigatorBuilder
 import com.a10miaomiao.bilimiao.comm.navigation.navigateToCompose
 import com.a10miaomiao.bilimiao.comm.navigation.openSearch
 import com.a10miaomiao.bilimiao.comm.recycler.RecyclerViewFragment
 import com.a10miaomiao.bilimiao.comm.store.UserStore
-import com.a10miaomiao.bilimiao.comm.utils.DebugMiao
-import com.a10miaomiao.bilimiao.page.home.*
+import com.a10miaomiao.bilimiao.comm.tabLayout
+import com.a10miaomiao.bilimiao.comm.views
 import com.a10miaomiao.bilimiao.page.setting.HomeSettingFragment
 import com.a10miaomiao.bilimiao.page.user.HistoryFragment
 import com.a10miaomiao.bilimiao.store.WindowStore
-import com.a10miaomiao.bilimiao.template.SettingFragment
 import com.a10miaomiao.bilimiao.widget.scaffold.getScaffoldView
 import com.a10miaomiao.bilimiao.widget.wrapInViewPager2Container
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import com.kongzue.dialogx.dialogs.PopTip
 import kotlinx.coroutines.launch
-import org.kodein.di.*
-import splitties.dimensions.dip
+import org.kodein.di.DI
+import org.kodein.di.DIAware
+import org.kodein.di.instance
 import splitties.experimental.InternalSplittiesApi
-import splitties.views.dsl.core.*
+import splitties.views.dsl.core.lParams
+import splitties.views.dsl.core.matchParent
+import splitties.views.dsl.core.space
+import splitties.views.dsl.core.verticalLayout
+import splitties.views.dsl.core.view
+import splitties.views.dsl.core.wrapContent
 
 
 class MainFragment : Fragment(), DIAware, MyPage {
@@ -101,8 +110,7 @@ class MainFragment : Fragment(), DIAware, MyPage {
 
     override fun onMenuItemClick(view: View, menuItem: MenuItemPropInfo) {
         super.onMenuItemClick(view, menuItem)
-        val nav = (activity as? MainActivity)?.pointerNav?.navController
-            ?: requireActivity().findNavController(R.id.nav_host_fragment)
+        val nav = NavHosts.pointerNavController
         when (menuItem.key) {
             MenuKeys.setting -> {
                 val scaffoldApp = requireActivity().getScaffoldView()

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/home/DynamicFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/home/DynamicFragment.kt
@@ -4,19 +4,26 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.os.bundleOf
-import androidx.fragment.app.Fragment
-import androidx.navigation.Navigation
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import bilibili.app.dynamic.v2.ModuleOuterClass
 import cn.a10miaomiao.miao.binding.android.view._tag
 import cn.a10miaomiao.miao.binding.miaoEffect
-import com.a10miaomiao.bilimiao.MainNavGraph
-import com.a10miaomiao.bilimiao.comm.*
-import com.a10miaomiao.bilimiao.comm.delegate.theme.ThemeDelegate
-import com.a10miaomiao.bilimiao.comm.recycler.*
+import com.a10miaomiao.bilimiao.comm.NavHosts
+import com.a10miaomiao.bilimiao.comm._isRefreshing
+import com.a10miaomiao.bilimiao.comm.diViewModel
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
+import com.a10miaomiao.bilimiao.comm.miaoStore
+import com.a10miaomiao.bilimiao.comm.recycler.RecyclerViewFragment
+import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
+import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
+import com.a10miaomiao.bilimiao.comm.recycler.footerViews
+import com.a10miaomiao.bilimiao.comm.recycler.lParams
+import com.a10miaomiao.bilimiao.comm.recycler.miaoBindingItemUi
+import com.a10miaomiao.bilimiao.comm.views
+import com.a10miaomiao.bilimiao.comm.wrapInSwipeRefreshLayout
 import com.a10miaomiao.bilimiao.commponents.dynamic.dynamicCardView
 import com.a10miaomiao.bilimiao.commponents.loading.ListState
 import com.a10miaomiao.bilimiao.commponents.loading.listStateView
@@ -30,11 +37,12 @@ import com.a10miaomiao.bilimiao.widget.recyclerviewAtViewPager2
 import com.chad.library.adapter.base.listener.OnItemClickListener
 import org.kodein.di.DI
 import org.kodein.di.DIAware
-import org.kodein.di.instance
 import splitties.toast.toast
 import splitties.views.backgroundColor
-import splitties.views.dsl.core.*
-import splitties.views.dsl.recyclerview.recyclerView
+import splitties.views.dsl.core.lParams
+import splitties.views.dsl.core.matchParent
+import splitties.views.dsl.core.verticalLayout
+import splitties.views.dsl.core.wrapContent
 
 class DynamicFragment: RecyclerViewFragment(), DIAware {
 
@@ -90,16 +98,15 @@ class DynamicFragment: RecyclerViewFragment(), DIAware {
             && tag.second is String
         ) {
             val (type, id) = tag as Pair<Int, String>
+            val nav = NavHosts.pointerNavController
             when(type) {
                 ModuleOuterClass.ModuleDynamicType.mdl_dyn_archive_VALUE -> {
                     val args = UserFragment.createArguments(id)
-                    Navigation.findNavController(it)
-                        .navigate(UserFragment.actionId, args)
+                    nav.navigate(UserFragment.actionId, args)
                 }
                 ModuleOuterClass.ModuleDynamicType.mdl_dyn_pgc_VALUE -> {
                     val args = BangumiDetailFragment.createArguments(id)
-                    Navigation.findNavController(it)
-                        .navigate(BangumiDetailFragment.actionId, args)
+                    nav.navigate(BangumiDetailFragment.actionId, args)
                 }
                 else -> {
                     toast("未知跳转类型")
@@ -112,16 +119,15 @@ class DynamicFragment: RecyclerViewFragment(), DIAware {
         val index = it.tag
         if (index is Int && index in viewModel.list.data.indices) {
             val item = viewModel.list.data[index]
+            val nav = NavHosts.pointerNavController
             when(item.dynamicType) {
                 ModuleOuterClass.ModuleDynamicType.mdl_dyn_archive_VALUE -> {
                     val args = VideoInfoFragment.createArguments(item.dynamicContent.id)
-                    Navigation.findNavController(it)
-                        .navigate(VideoInfoFragment.actionId, args)
+                    nav.navigate(VideoInfoFragment.actionId, args)
                 }
                 ModuleOuterClass.ModuleDynamicType.mdl_dyn_pgc_VALUE -> {
                     val args = BangumiDetailFragment.createArguments(item.dynamicContent.id)
-                    Navigation.findNavController(it)
-                        .navigate(BangumiDetailFragment.actionId, args)
+                    nav.navigate(BangumiDetailFragment.actionId, args)
                 }
                 else -> {
                     toast("未知跳转类型")

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/home/PopularFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/home/PopularFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.navigation.Navigation
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -13,24 +12,43 @@ import bilibili.app.card.v1.Single
 import bilibili.app.show.v1.PopularOuterClass
 import cn.a10miaomiao.miao.binding.android.view._bottomMargin
 import cn.a10miaomiao.miao.binding.android.widget._text
-import com.a10miaomiao.bilimiao.comm.*
-import com.a10miaomiao.bilimiao.comm.delegate.theme.ThemeDelegate
-import com.a10miaomiao.bilimiao.comm.recycler.*
+import com.a10miaomiao.bilimiao.comm.BiliNavigation
+import com.a10miaomiao.bilimiao.comm.NavHosts
+import com.a10miaomiao.bilimiao.comm._isRefreshing
+import com.a10miaomiao.bilimiao.comm._network
+import com.a10miaomiao.bilimiao.comm.diViewModel
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
+import com.a10miaomiao.bilimiao.comm.miaoStore
+import com.a10miaomiao.bilimiao.comm.recycler.GridAutofitLayoutManager
+import com.a10miaomiao.bilimiao.comm.recycler.RecyclerViewFragment
+import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
+import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
+import com.a10miaomiao.bilimiao.comm.recycler.footerViews
+import com.a10miaomiao.bilimiao.comm.recycler.headerViews
+import com.a10miaomiao.bilimiao.comm.recycler.lParams
+import com.a10miaomiao.bilimiao.comm.recycler.miaoBindingItemUi
+import com.a10miaomiao.bilimiao.comm.views
+import com.a10miaomiao.bilimiao.comm.wrapInSwipeRefreshLayout
 import com.a10miaomiao.bilimiao.commponents.loading.ListState
 import com.a10miaomiao.bilimiao.commponents.loading.listStateView
 import com.a10miaomiao.bilimiao.commponents.video.videoItem
 import com.a10miaomiao.bilimiao.config.config
-import com.a10miaomiao.bilimiao.page.web.WebFragment
 import com.a10miaomiao.bilimiao.page.video.VideoInfoFragment
+import com.a10miaomiao.bilimiao.page.web.WebFragment
 import com.a10miaomiao.bilimiao.store.WindowStore
 import com.a10miaomiao.bilimiao.widget.recyclerviewAtViewPager2
 import com.chad.library.adapter.base.listener.OnItemClickListener
 import org.kodein.di.DI
 import org.kodein.di.DIAware
-import org.kodein.di.instance
 import splitties.dimensions.dip
 import splitties.views.backgroundColor
-import splitties.views.dsl.core.*
+import splitties.views.dsl.core.imageView
+import splitties.views.dsl.core.lParams
+import splitties.views.dsl.core.matchParent
+import splitties.views.dsl.core.textView
+import splitties.views.dsl.core.verticalLayout
+import splitties.views.dsl.core.wrapContent
 import splitties.views.dsl.recyclerview.recyclerView
 import splitties.views.gravityCenter
 import splitties.views.verticalPadding
@@ -86,8 +104,8 @@ class PopularFragment: RecyclerViewFragment(), DIAware {
     private val handleItemClick = OnItemClickListener { adapter, view, position ->
         val item = viewModel.list.data[position]
         val args = VideoInfoFragment.createArguments(item.base.param)
-        Navigation.findNavController(view)
-            .navigate(VideoInfoFragment.actionId, args)
+        val nav = NavHosts.pointerNavController
+        nav.navigate(VideoInfoFragment.actionId, args)
     }
 
     val topEntranceItemUi = miaoBindingItemUi<PopularOuterClass.EntranceShow> { item, index ->

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/home/RecommendFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/home/RecommendFragment.kt
@@ -4,15 +4,29 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.navigation.Navigation
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import cn.a10miaomiao.bilimiao.compose.pages.bangumi.BangumiDetailPage
 import cn.a10miaomiao.miao.binding.android.view._bottomPadding
-import com.a10miaomiao.bilimiao.comm.*
+import com.a10miaomiao.bilimiao.comm.BiliNavigation
+import com.a10miaomiao.bilimiao.comm.NavHosts
+import com.a10miaomiao.bilimiao.comm._isRefreshing
+import com.a10miaomiao.bilimiao.comm.diViewModel
 import com.a10miaomiao.bilimiao.comm.entity.home.RecommendCardInfo
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
+import com.a10miaomiao.bilimiao.comm.miaoStore
 import com.a10miaomiao.bilimiao.comm.navigation.navigateToCompose
-import com.a10miaomiao.bilimiao.comm.recycler.*
+import com.a10miaomiao.bilimiao.comm.recycler.GridAutofitLayoutManager
+import com.a10miaomiao.bilimiao.comm.recycler.MiaoBindingAdapter
+import com.a10miaomiao.bilimiao.comm.recycler.RecyclerViewFragment
+import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
+import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
+import com.a10miaomiao.bilimiao.comm.recycler.footerViews
+import com.a10miaomiao.bilimiao.comm.recycler.lParams
+import com.a10miaomiao.bilimiao.comm.recycler.miaoBindingItemUi
+import com.a10miaomiao.bilimiao.comm.views
+import com.a10miaomiao.bilimiao.comm.wrapInSwipeRefreshLayout
 import com.a10miaomiao.bilimiao.commponents.loading.ListState
 import com.a10miaomiao.bilimiao.commponents.loading.listStateView
 import com.a10miaomiao.bilimiao.commponents.video.miniVideoItem
@@ -26,7 +40,10 @@ import org.kodein.di.DI
 import org.kodein.di.DIAware
 import splitties.dimensions.dip
 import splitties.views.backgroundColor
-import splitties.views.dsl.core.*
+import splitties.views.dsl.core.lParams
+import splitties.views.dsl.core.matchParent
+import splitties.views.dsl.core.verticalLayout
+import splitties.views.dsl.core.wrapContent
 
 class RecommendFragment: RecyclerViewFragment(), DIAware {
 
@@ -63,7 +80,7 @@ class RecommendFragment: RecyclerViewFragment(), DIAware {
     }
 
     private val handleItemClick = OnItemClickListener { adapter, view, position ->
-        val nav = Navigation.findNavController(view)
+        val nav = NavHosts.pointerNavController
         val item = viewModel.list.data[position]
 
         if (item.goto == "av" || item.goto == "vertical_av") {

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/rank/RankDetailFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/rank/RankDetailFragment.kt
@@ -6,18 +6,26 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import androidx.core.os.bundleOf
-import androidx.fragment.app.Fragment
-import androidx.navigation.Navigation
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import bilibili.app.show.v1.RankOuterClass
 import cn.a10miaomiao.miao.binding.android.widget._text
 import cn.a10miaomiao.miao.binding.android.widget._textColorResource
-import com.a10miaomiao.bilimiao.MainNavGraph
 import com.a10miaomiao.bilimiao.R
-import com.a10miaomiao.bilimiao.comm.*
-import com.a10miaomiao.bilimiao.comm.recycler.*
+import com.a10miaomiao.bilimiao.comm.NavHosts
+import com.a10miaomiao.bilimiao.comm._isRefreshing
+import com.a10miaomiao.bilimiao.comm.diViewModel
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
+import com.a10miaomiao.bilimiao.comm.miaoStore
+import com.a10miaomiao.bilimiao.comm.recycler.GridAutofitLayoutManager
+import com.a10miaomiao.bilimiao.comm.recycler.RecyclerViewFragment
+import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
+import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
+import com.a10miaomiao.bilimiao.comm.recycler.lParams
+import com.a10miaomiao.bilimiao.comm.recycler.miaoBindingItemUi
+import com.a10miaomiao.bilimiao.comm.views
+import com.a10miaomiao.bilimiao.comm.wrapInSwipeRefreshLayout
 import com.a10miaomiao.bilimiao.commponents.loading.ListState
 import com.a10miaomiao.bilimiao.commponents.loading.listStateView
 import com.a10miaomiao.bilimiao.commponents.video.videoItem
@@ -29,7 +37,12 @@ import org.kodein.di.DI
 import org.kodein.di.DIAware
 import splitties.dimensions.dip
 import splitties.views.backgroundColor
-import splitties.views.dsl.core.*
+import splitties.views.dsl.core.horizontalLayout
+import splitties.views.dsl.core.lParams
+import splitties.views.dsl.core.matchParent
+import splitties.views.dsl.core.textView
+import splitties.views.dsl.core.verticalLayout
+import splitties.views.dsl.core.wrapContent
 import splitties.views.dsl.recyclerview.recyclerView
 import splitties.views.padding
 
@@ -72,8 +85,7 @@ class RankDetailFragment : RecyclerViewFragment(), DIAware {
     private val handleItemClick = OnItemClickListener { adapter, view, position ->
         val item = viewModel.list.data[position]
         val args = VideoInfoFragment.createArguments(item.param)
-        Navigation.findNavController(view)
-            .navigate(VideoInfoFragment.actionId, args)
+        NavHosts.pointerNavController.navigate(VideoInfoFragment.actionId, args)
     }
 
     val itemUi = miaoBindingItemUi<RankOuterClass.Item> { item, index ->

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/region/RegionDetailsFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/region/RegionDetailsFragment.kt
@@ -4,22 +4,30 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.os.bundleOf
-import androidx.fragment.app.Fragment
 import androidx.lifecycle.coroutineScope
-import androidx.navigation.Navigation
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-import com.a10miaomiao.bilimiao.MainNavGraph
+import com.a10miaomiao.bilimiao.comm.NavHosts
+import com.a10miaomiao.bilimiao.comm._isRefreshing
+import com.a10miaomiao.bilimiao.comm.diViewModel
 import com.a10miaomiao.bilimiao.comm.entity.region.RegionTypeDetailsInfo
-import com.a10miaomiao.bilimiao.config.config
-import com.a10miaomiao.bilimiao.comm.*
-import com.a10miaomiao.bilimiao.comm.recycler.*
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
+import com.a10miaomiao.bilimiao.comm.miaoStore
+import com.a10miaomiao.bilimiao.comm.recycler.GridAutofitLayoutManager
+import com.a10miaomiao.bilimiao.comm.recycler.RecyclerViewFragment
+import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
+import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
+import com.a10miaomiao.bilimiao.comm.recycler.lParams
+import com.a10miaomiao.bilimiao.comm.recycler.miaoBindingItemUi
+import com.a10miaomiao.bilimiao.comm.store.TimeSettingStore
+import com.a10miaomiao.bilimiao.comm.utils.NumberUtil
+import com.a10miaomiao.bilimiao.comm.views
+import com.a10miaomiao.bilimiao.comm.wrapInSwipeRefreshLayout
 import com.a10miaomiao.bilimiao.commponents.loading.ListState
 import com.a10miaomiao.bilimiao.commponents.loading.listStateView
 import com.a10miaomiao.bilimiao.commponents.video.videoItem
-import com.a10miaomiao.bilimiao.comm.store.TimeSettingStore
-import com.a10miaomiao.bilimiao.comm.utils.NumberUtil
+import com.a10miaomiao.bilimiao.config.config
 import com.a10miaomiao.bilimiao.page.video.VideoInfoFragment
 import com.a10miaomiao.bilimiao.store.WindowStore
 import com.chad.library.adapter.base.listener.OnItemClickListener
@@ -28,7 +36,10 @@ import org.kodein.di.DIAware
 import org.kodein.di.instance
 import splitties.dimensions.dip
 import splitties.views.backgroundColor
-import splitties.views.dsl.core.*
+import splitties.views.dsl.core.lParams
+import splitties.views.dsl.core.matchParent
+import splitties.views.dsl.core.verticalLayout
+import splitties.views.dsl.core.wrapContent
 import splitties.views.dsl.recyclerview.recyclerView
 
 class RegionDetailsFragment : RecyclerViewFragment(), DIAware {
@@ -91,8 +102,7 @@ class RegionDetailsFragment : RecyclerViewFragment(), DIAware {
     private val handleItemClick = OnItemClickListener { adapter, view, position ->
         val item = viewModel.list.data[position]
         val args = VideoInfoFragment.createArguments(item.id)
-        Navigation.findNavController(view)
-            .navigate(VideoInfoFragment.actionId, args)
+        NavHosts.pointerNavController.navigate(VideoInfoFragment.actionId, args)
     }
 
     val itemUi = miaoBindingItemUi<RegionTypeDetailsInfo> { item, index ->

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/search/SearchStartFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/search/SearchStartFragment.kt
@@ -3,7 +3,11 @@ package com.a10miaomiao.bilimiao.page.search
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
-import android.view.*
+import android.view.Gravity
+import android.view.KeyEvent
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.widget.CompoundButton
 import android.widget.EditText
@@ -12,16 +16,22 @@ import android.widget.TextView
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavType
-import androidx.navigation.Navigation
-import androidx.navigation.findNavController
 import androidx.navigation.fragment.FragmentNavigatorDestinationBuilder
-import androidx.navigation.fragment.findNavController
-import cn.a10miaomiao.miao.binding.android.view.*
+import cn.a10miaomiao.miao.binding.android.view._bottomPadding
+import cn.a10miaomiao.miao.binding.android.view._leftPadding
+import cn.a10miaomiao.miao.binding.android.view._rightPadding
+import cn.a10miaomiao.miao.binding.android.view._show
+import cn.a10miaomiao.miao.binding.android.view._topPadding
 import cn.a10miaomiao.miao.binding.android.widget._text
-import com.a10miaomiao.bilimiao.MainActivity
 import com.a10miaomiao.bilimiao.R
-import com.a10miaomiao.bilimiao.comm.*
+import com.a10miaomiao.bilimiao.comm.MiaoUI
+import com.a10miaomiao.bilimiao.comm.NavHosts
 import com.a10miaomiao.bilimiao.comm.delegate.helper.SupportHelper
+import com.a10miaomiao.bilimiao.comm.diViewModel
+import com.a10miaomiao.bilimiao.comm.flexboxLayout
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
+import com.a10miaomiao.bilimiao.comm.miaoStore
 import com.a10miaomiao.bilimiao.comm.mypage.MyPage
 import com.a10miaomiao.bilimiao.comm.mypage.SearchConfigInfo
 import com.a10miaomiao.bilimiao.comm.mypage.myPageConfig
@@ -30,6 +40,8 @@ import com.a10miaomiao.bilimiao.comm.navigation.MainNavArgs
 import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
 import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
 import com.a10miaomiao.bilimiao.comm.recycler.miaoBindingItemUi
+import com.a10miaomiao.bilimiao.comm.views
+import com.a10miaomiao.bilimiao.comm.wrapInNestedScrollView
 import com.a10miaomiao.bilimiao.config.ViewStyle
 import com.a10miaomiao.bilimiao.config.config
 import com.a10miaomiao.bilimiao.page.bangumi.BangumiDetailFragment
@@ -46,9 +58,23 @@ import org.kodein.di.DIAware
 import org.kodein.di.instance
 import splitties.dimensions.dip
 import splitties.toast.toast
-import splitties.views.*
-import splitties.views.dsl.core.*
+import splitties.views.backgroundColor
+import splitties.views.bottomPadding
+import splitties.views.dsl.core.editText
+import splitties.views.dsl.core.frameLayout
+import splitties.views.dsl.core.horizontalLayout
+import splitties.views.dsl.core.horizontalMargin
+import splitties.views.dsl.core.imageView
+import splitties.views.dsl.core.lParams
+import splitties.views.dsl.core.matchParent
+import splitties.views.dsl.core.radioButton
+import splitties.views.dsl.core.textView
+import splitties.views.dsl.core.verticalLayout
+import splitties.views.dsl.core.verticalMargin
+import splitties.views.dsl.core.wrapContent
 import splitties.views.dsl.recyclerview.recyclerView
+import splitties.views.horizontalPadding
+import splitties.views.padding
 
 class SearchStartFragment : Fragment(), DIAware, MyPage {
 
@@ -198,16 +224,14 @@ class SearchStartFragment : Fragment(), DIAware, MyPage {
                 "AV" -> {
 //                    scaffoldApp.closeSearchDrawer()
 //                    Navigation.findNavController(view).popBackStack()
-                    val nav = (activity as? MainActivity)?.pointerNav?.navController
-                        ?: requireActivity().findNavController(R.id.nav_host_fragment)
+                    val nav = NavHosts.pointerNavController
                     val args = VideoInfoFragment.createArguments(item.value)
                     nav.navigate(VideoInfoFragment.actionId, args)
                 }
                 "SS" -> {
 //                    scaffoldApp.closeSearchDrawer()
 //                    Navigation.findNavController(view).popBackStack()
-                    val nav = (activity as? MainActivity)?.pointerNav?.navController
-                        ?: requireActivity().findNavController(R.id.nav_host_fragment)
+                    val nav = NavHosts.pointerNavController
                     val args = BangumiDetailFragment.createArguments(item.value)
                     nav.navigate(BangumiDetailFragment.actionId, args)
                 }

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/search/SearchStartViewModel.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/search/SearchStartViewModel.kt
@@ -1,26 +1,20 @@
 package com.a10miaomiao.bilimiao.page.search
 
-import android.content.Context
 import android.view.View
 import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.bundleOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.navigation.Navigation
-import androidx.navigation.findNavController
-import androidx.navigation.fragment.findNavController
 import com.a10miaomiao.bilimiao.MainActivity
-import com.a10miaomiao.bilimiao.MainNavGraph
-import com.a10miaomiao.bilimiao.R
 import com.a10miaomiao.bilimiao.comm.MiaoBindingUi
+import com.a10miaomiao.bilimiao.comm.NavHosts
 import com.a10miaomiao.bilimiao.comm.db.SearchHistoryDB
 import com.a10miaomiao.bilimiao.comm.navigation.MainNavArgs
 import com.a10miaomiao.bilimiao.comm.network.BiliApiService
 import com.a10miaomiao.bilimiao.widget.scaffold.getScaffoldView
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import org.json.JSONException
 import org.json.JSONObject
 import org.json.JSONTokener
 import org.kodein.di.DI
@@ -121,8 +115,7 @@ class SearchStartViewModel (
         searchHistoryDB.insertHistory(keyword)
         activity.getScaffoldView().closeDrawer()
         if (searchMode == 0) {
-            val nav = (activity as? MainActivity)?.pointerNav?.navController
-                ?: activity.findNavController(R.id.nav_host_fragment)
+            val nav = NavHosts.currentNavController
             val args = bundleOf(
                 MainNavArgs.text to keyword
             )

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/search/result/BangumiResultFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/search/result/BangumiResultFragment.kt
@@ -4,17 +4,26 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.navigation.Navigation
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import cn.a10miaomiao.bilimiao.compose.pages.bangumi.BangumiDetailPage
 import cn.a10miaomiao.miao.binding.android.view._bottomPadding
-import com.a10miaomiao.bilimiao.comm.*
+import com.a10miaomiao.bilimiao.comm.NavHosts
+import com.a10miaomiao.bilimiao.comm._isRefreshing
+import com.a10miaomiao.bilimiao.comm.diViewModel
 import com.a10miaomiao.bilimiao.comm.entity.search.SearchBangumiInfo
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
+import com.a10miaomiao.bilimiao.comm.miaoStore
 import com.a10miaomiao.bilimiao.comm.mypage.MenuItemPropInfo
 import com.a10miaomiao.bilimiao.comm.navigation.MainNavArgs
 import com.a10miaomiao.bilimiao.comm.navigation.navigateToCompose
-import com.a10miaomiao.bilimiao.comm.recycler.*
+import com.a10miaomiao.bilimiao.comm.recycler.GridAutofitLayoutManager
+import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
+import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
+import com.a10miaomiao.bilimiao.comm.recycler.miaoBindingItemUi
+import com.a10miaomiao.bilimiao.comm.views
+import com.a10miaomiao.bilimiao.comm.wrapInSwipeRefreshLayout
 import com.a10miaomiao.bilimiao.commponents.bangumi.bangumiItem
 import com.a10miaomiao.bilimiao.commponents.loading.ListState
 import com.a10miaomiao.bilimiao.commponents.loading.listStateView
@@ -78,8 +87,7 @@ class BangumiResultFragment : BaseResultFragment(), DIAware {
 
     private val handleItemClick = OnItemClickListener { adapter, view, position ->
         val item = viewModel.list.data[position]
-        Navigation.findNavController(view)
-            .navigateToCompose(BangumiDetailPage()) {
+        NavHosts.pointerNavController.navigateToCompose(BangumiDetailPage()) {
                 //api原因，从param改为season_id.toString()
                 id set item.season_id.toString()
             }

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/search/result/UpperResultFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/search/result/UpperResultFragment.kt
@@ -4,18 +4,25 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.os.bundleOf
-import androidx.navigation.Navigation
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import cn.a10miaomiao.miao.binding.android.view._bottomPadding
-import com.a10miaomiao.bilimiao.MainNavGraph
-import com.a10miaomiao.bilimiao.comm.*
+import com.a10miaomiao.bilimiao.comm.NavHosts
+import com.a10miaomiao.bilimiao.comm._isRefreshing
+import com.a10miaomiao.bilimiao.comm.diViewModel
 import com.a10miaomiao.bilimiao.comm.entity.search.SearchUpperInfo
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
+import com.a10miaomiao.bilimiao.comm.miaoStore
 import com.a10miaomiao.bilimiao.comm.mypage.MenuItemPropInfo
 import com.a10miaomiao.bilimiao.comm.navigation.MainNavArgs
-import com.a10miaomiao.bilimiao.comm.recycler.*
+import com.a10miaomiao.bilimiao.comm.recycler.GridAutofitLayoutManager
+import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
+import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
+import com.a10miaomiao.bilimiao.comm.recycler.miaoBindingItemUi
 import com.a10miaomiao.bilimiao.comm.utils.NumberUtil
+import com.a10miaomiao.bilimiao.comm.views
+import com.a10miaomiao.bilimiao.comm.wrapInSwipeRefreshLayout
 import com.a10miaomiao.bilimiao.commponents.loading.ListState
 import com.a10miaomiao.bilimiao.commponents.loading.listStateView
 import com.a10miaomiao.bilimiao.commponents.upper.upperItem
@@ -81,8 +88,7 @@ class UpperResultFragment : BaseResultFragment(), DIAware {
     private val handleItemClick = OnItemClickListener { adapter, view, position ->
         val item = viewModel.list.data[position]
         val args = UserFragment.createArguments(item.param)
-        Navigation.findNavController(view)
-            .navigate(UserFragment.actionId, args)
+        NavHosts.pointerNavController.navigate(UserFragment.actionId, args)
     }
 
     val itemUi = miaoBindingItemUi<SearchUpperInfo> { item, index ->

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/search/result/VideoRegionFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/search/result/VideoRegionFragment.kt
@@ -11,20 +11,32 @@ import androidx.navigation.NavType
 import androidx.navigation.fragment.FragmentNavigatorDestinationBuilder
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
-import cn.a10miaomiao.miao.binding.android.view.*
+import cn.a10miaomiao.miao.binding.android.view._bottomPadding
+import cn.a10miaomiao.miao.binding.android.view._leftPadding
+import cn.a10miaomiao.miao.binding.android.view._rightPadding
+import cn.a10miaomiao.miao.binding.android.view._topPadding
 import cn.a10miaomiao.miao.binding.android.widget._text
 import cn.a10miaomiao.miao.binding.android.widget._textColor
 import cn.a10miaomiao.miao.binding.miaoEffect
-import com.a10miaomiao.bilimiao.MainActivity
-import com.a10miaomiao.bilimiao.MainNavGraph
 import com.a10miaomiao.bilimiao.R
-import com.a10miaomiao.bilimiao.comm.*
+import com.a10miaomiao.bilimiao.comm.NavHosts
+import com.a10miaomiao.bilimiao.comm.connectStore
+import com.a10miaomiao.bilimiao.comm.diViewModel
 import com.a10miaomiao.bilimiao.comm.entity.region.RegionInfo
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.loadImageUrl
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
+import com.a10miaomiao.bilimiao.comm.miaoStore
 import com.a10miaomiao.bilimiao.comm.mypage.MyPage
 import com.a10miaomiao.bilimiao.comm.mypage.myPageConfig
 import com.a10miaomiao.bilimiao.comm.navigation.FragmentNavigatorBuilder
 import com.a10miaomiao.bilimiao.comm.navigation.MainNavArgs
-import com.a10miaomiao.bilimiao.comm.recycler.*
+import com.a10miaomiao.bilimiao.comm.recycler.GridAutofitLayoutManager
+import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
+import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
+import com.a10miaomiao.bilimiao.comm.recycler.miaoBindingItemUi
+import com.a10miaomiao.bilimiao.comm.shadowLayout
+import com.a10miaomiao.bilimiao.comm.views
 import com.a10miaomiao.bilimiao.config.config
 import com.a10miaomiao.bilimiao.page.search.SearchResultFragment
 import com.a10miaomiao.bilimiao.store.WindowStore
@@ -34,7 +46,13 @@ import org.kodein.di.DI
 import org.kodein.di.DIAware
 import splitties.dimensions.dip
 import splitties.views.backgroundColor
-import splitties.views.dsl.core.*
+import splitties.views.dsl.core.horizontalLayout
+import splitties.views.dsl.core.imageView
+import splitties.views.dsl.core.lParams
+import splitties.views.dsl.core.margin
+import splitties.views.dsl.core.matchParent
+import splitties.views.dsl.core.textView
+import splitties.views.dsl.core.wrapContent
 import splitties.views.dsl.recyclerview.recyclerView
 import splitties.views.verticalPadding
 
@@ -74,7 +92,7 @@ class VideoRegionFragment : Fragment(), DIAware, MyPage {
     }
 
     val handleItemClick = OnItemClickListener {  adapter, view, position ->
-        val navHostFragment = (activity as? MainActivity)?.currentNav
+        val navHostFragment = NavHosts.getCurrentHostFrag()
             ?: requireActivity().supportFragmentManager
                 .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
         val fragment = navHostFragment.childFragmentManager.primaryNavigationFragment

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/search/result/VideoResultFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/search/result/VideoResultFragment.kt
@@ -4,24 +4,29 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.os.bundleOf
-import androidx.navigation.Navigation
 import androidx.navigation.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-import cn.a10miaomiao.miao.binding.android.view._bottomMargin
 import cn.a10miaomiao.miao.binding.android.view._bottomPadding
-import com.a10miaomiao.bilimiao.MainNavGraph
 import com.a10miaomiao.bilimiao.R
-import com.a10miaomiao.bilimiao.comm.*
+import com.a10miaomiao.bilimiao.comm.NavHosts
+import com.a10miaomiao.bilimiao.comm._isRefreshing
+import com.a10miaomiao.bilimiao.comm.diViewModel
 import com.a10miaomiao.bilimiao.comm.entity.region.RegionInfo
 import com.a10miaomiao.bilimiao.comm.entity.search.SearchVideoInfo
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
+import com.a10miaomiao.bilimiao.comm.miaoStore
 import com.a10miaomiao.bilimiao.comm.mypage.MenuItemPropInfo
 import com.a10miaomiao.bilimiao.comm.mypage.MenuKeys
 import com.a10miaomiao.bilimiao.comm.mypage.myMenuItem
 import com.a10miaomiao.bilimiao.comm.navigation.MainNavArgs
-import com.a10miaomiao.bilimiao.comm.recycler.*
-import com.a10miaomiao.bilimiao.comm.utils.DebugMiao
+import com.a10miaomiao.bilimiao.comm.recycler.GridAutofitLayoutManager
+import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
+import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
+import com.a10miaomiao.bilimiao.comm.recycler.miaoBindingItemUi
+import com.a10miaomiao.bilimiao.comm.views
+import com.a10miaomiao.bilimiao.comm.wrapInSwipeRefreshLayout
 import com.a10miaomiao.bilimiao.commponents.loading.ListState
 import com.a10miaomiao.bilimiao.commponents.loading.listStateView
 import com.a10miaomiao.bilimiao.commponents.video.videoItem
@@ -37,7 +42,6 @@ import splitties.views.backgroundColor
 import splitties.views.dsl.core.lParams
 import splitties.views.dsl.core.matchParent
 import splitties.views.dsl.core.verticalLayout
-import splitties.views.dsl.core.wrapContent
 import splitties.views.dsl.recyclerview.recyclerView
 
 class VideoResultFragment : BaseResultFragment(), DIAware {
@@ -142,8 +146,7 @@ class VideoResultFragment : BaseResultFragment(), DIAware {
     private val handleItemClick = OnItemClickListener { adapter, view, position ->
         val item = viewModel.list.data[position]
         val args = VideoInfoFragment.createArguments(item.param)
-        Navigation.findNavController(view)
-            .navigate(VideoInfoFragment.actionId, args)
+        NavHosts.pointerNavController.navigate(VideoInfoFragment.actionId, args)
     }
 
     val itemUi = miaoBindingItemUi<SearchVideoInfo> { item, index ->

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/user/HistoryFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/user/HistoryFragment.kt
@@ -21,8 +21,18 @@ import cn.a10miaomiao.miao.binding.android.view._leftPadding
 import cn.a10miaomiao.miao.binding.android.view._rightPadding
 import cn.a10miaomiao.miao.binding.android.view._topPadding
 import com.a10miaomiao.bilimiao.R
-import com.a10miaomiao.bilimiao.comm.*
-import com.a10miaomiao.bilimiao.comm.mypage.*
+import com.a10miaomiao.bilimiao.comm.NavHosts
+import com.a10miaomiao.bilimiao.comm._isRefreshing
+import com.a10miaomiao.bilimiao.comm.connectUi
+import com.a10miaomiao.bilimiao.comm.diViewModel
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
+import com.a10miaomiao.bilimiao.comm.mypage.MenuItemPropInfo
+import com.a10miaomiao.bilimiao.comm.mypage.MenuKeys
+import com.a10miaomiao.bilimiao.comm.mypage.MyPage
+import com.a10miaomiao.bilimiao.comm.mypage.SearchConfigInfo
+import com.a10miaomiao.bilimiao.comm.mypage.myMenuItem
+import com.a10miaomiao.bilimiao.comm.mypage.myPageConfig
 import com.a10miaomiao.bilimiao.comm.navigation.FragmentNavigatorBuilder
 import com.a10miaomiao.bilimiao.comm.navigation.MainNavArgs
 import com.a10miaomiao.bilimiao.comm.navigation.navigateToCompose
@@ -32,6 +42,7 @@ import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
 import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
 import com.a10miaomiao.bilimiao.comm.recycler.miaoBindingItemUi
 import com.a10miaomiao.bilimiao.comm.utils.NumberUtil
+import com.a10miaomiao.bilimiao.comm.wrapInSwipeRefreshLayout
 import com.a10miaomiao.bilimiao.commponents.loading.ListState
 import com.a10miaomiao.bilimiao.commponents.loading.listStateView
 import com.a10miaomiao.bilimiao.commponents.video.videoItem
@@ -145,7 +156,7 @@ class HistoryFragment : Fragment(), DIAware, MyPage {
 
     private val handleItemClick = OnItemClickListener { adapter, view, position ->
         val item = viewModel.list.data[position]
-        val nav = Navigation.findNavController(view)
+        val nav = NavHosts.pointerNavController
         when(item.business) {
             "archive" -> {
                 val args = VideoInfoFragment.createArguments(item.oid.toString())

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/user/UserFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/user/UserFragment.kt
@@ -2,40 +2,60 @@ package com.a10miaomiao.bilimiao.page.user
 
 import android.os.Bundle
 import android.text.TextUtils
-import android.view.*
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.coroutineScope
 import androidx.navigation.NavType
-import androidx.navigation.Navigation
-import androidx.navigation.findNavController
 import androidx.navigation.fragment.FragmentNavigatorDestinationBuilder
 import androidx.recyclerview.widget.LinearLayoutManager
 import cn.a10miaomiao.bilimiao.compose.pages.bangumi.BangumiDetailPage
 import cn.a10miaomiao.bilimiao.compose.pages.user.MyFollowPage
 import cn.a10miaomiao.bilimiao.compose.pages.user.UserFollowPage
-import cn.a10miaomiao.miao.binding.android.view.*
+import cn.a10miaomiao.miao.binding.android.view._leftPadding
+import cn.a10miaomiao.miao.binding.android.view._rightPadding
+import cn.a10miaomiao.miao.binding.android.view._show
+import cn.a10miaomiao.miao.binding.android.view._topMargin
+import cn.a10miaomiao.miao.binding.android.view._topPadding
 import cn.a10miaomiao.miao.binding.android.widget._text
 import cn.a10miaomiao.miao.binding.miaoEffect
 import cn.a10miaomiao.miao.binding.miaoMemo
 import com.a10miaomiao.bilimiao.R
-import com.a10miaomiao.bilimiao.comm.*
+import com.a10miaomiao.bilimiao.comm.MiaoUI
+import com.a10miaomiao.bilimiao.comm.NavHosts
+import com.a10miaomiao.bilimiao.comm._isRefreshing
+import com.a10miaomiao.bilimiao.comm._network
+import com.a10miaomiao.bilimiao.comm.connectUi
 import com.a10miaomiao.bilimiao.comm.delegate.theme.ThemeDelegate
+import com.a10miaomiao.bilimiao.comm.diViewModel
 import com.a10miaomiao.bilimiao.comm.entity.user.SpaceInfo
 import com.a10miaomiao.bilimiao.comm.entity.user.UpperChannelInfo
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.loadImageUrl
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
+import com.a10miaomiao.bilimiao.comm.mypage.MenuItemPropInfo
+import com.a10miaomiao.bilimiao.comm.mypage.MenuKeys
 import com.a10miaomiao.bilimiao.comm.mypage.MyPage
 import com.a10miaomiao.bilimiao.comm.mypage.myMenuItem
 import com.a10miaomiao.bilimiao.comm.mypage.myPageConfig
-import com.a10miaomiao.bilimiao.comm.mypage.MenuItemPropInfo
-import com.a10miaomiao.bilimiao.comm.mypage.MenuKeys
 import com.a10miaomiao.bilimiao.comm.navigation.FragmentNavigatorBuilder
 import com.a10miaomiao.bilimiao.comm.navigation.MainNavArgs
 import com.a10miaomiao.bilimiao.comm.navigation.navigateToCompose
-import com.a10miaomiao.bilimiao.comm.recycler.*
+import com.a10miaomiao.bilimiao.comm.recycler.GridAutofitLayoutManager
+import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
+import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
+import com.a10miaomiao.bilimiao.comm.recycler.headerViews
+import com.a10miaomiao.bilimiao.comm.recycler.lParams
+import com.a10miaomiao.bilimiao.comm.recycler.miaoBindingItemUi
 import com.a10miaomiao.bilimiao.comm.utils.ImageSaveUtil
 import com.a10miaomiao.bilimiao.comm.utils.NumberUtil
+import com.a10miaomiao.bilimiao.comm.views
+import com.a10miaomiao.bilimiao.comm.wrapInSwipeRefreshLayout
 import com.a10miaomiao.bilimiao.commponents.season.miniSeasonItemView
 import com.a10miaomiao.bilimiao.commponents.video.mediaItemView
 import com.a10miaomiao.bilimiao.config.ViewStyle
@@ -60,7 +80,16 @@ import org.kodein.di.instance
 import splitties.dimensions.dip
 import splitties.toast.toast
 import splitties.views.backgroundColor
-import splitties.views.dsl.core.*
+import splitties.views.dsl.core.frameLayout
+import splitties.views.dsl.core.horizontalLayout
+import splitties.views.dsl.core.horizontalMargin
+import splitties.views.dsl.core.imageView
+import splitties.views.dsl.core.lParams
+import splitties.views.dsl.core.matchParent
+import splitties.views.dsl.core.textView
+import splitties.views.dsl.core.verticalLayout
+import splitties.views.dsl.core.verticalMargin
+import splitties.views.dsl.core.wrapContent
 import splitties.views.dsl.recyclerview.recyclerView
 import splitties.views.horizontalPadding
 import splitties.views.padding
@@ -177,31 +206,27 @@ class UserFragment : Fragment(), DIAware, MyPage {
         if (info == null) {
             toast("操作失败，信息未加载完成")
         } else {
+            val nav = NavHosts.currentNavController
             when (it.tag) {
                 "archive" -> {
                     val args = UserArchiveListFragment.createArguments(viewModel.id, info.card.name)
-                    Navigation.findNavController(it)
-                        .navigate(UserArchiveListFragment.actionId, args)
+                    nav.navigate(UserArchiveListFragment.actionId, args)
                 }
                 "season" -> {
                     if (viewModel.isSelf) {
-                        Navigation.findNavController(it)
-                            .navigate(MyBangumiFragment.actionId)
+                        nav.navigate(MyBangumiFragment.actionId)
                     } else {
                         val args = UserBangumiFragment.createArguments(viewModel.id, info.card.name)
-                        Navigation.findNavController(it)
-                            .navigate(UserBangumiFragment.actionId, args)
+                        nav.navigate(UserBangumiFragment.actionId, args)
                     }
 
                 }
                 "favourite" -> {
                     val args =
                         UserFavouriteListFragment.createArguments(viewModel.id, info.card.name)
-                    Navigation.findNavController(it)
-                        .navigate(UserFavouriteListFragment.actionId, args)
+                    nav.navigate(UserFavouriteListFragment.actionId, args)
                 }
                 "attention" -> {
-                    val nav = it.findNavController()
                     if (viewModel.isSelf) {
                         nav.navigateToCompose(MyFollowPage())
                     } else {
@@ -217,8 +242,7 @@ class UserFragment : Fragment(), DIAware, MyPage {
                         type = "fans",
                         name = info.card.name,
                     )
-                    Navigation.findNavController(it)
-                        .navigate(UserFollowFragment.actionId, args)
+                    nav.navigate(UserFollowFragment.actionId, args)
                 }
             }
         }
@@ -227,12 +251,12 @@ class UserFragment : Fragment(), DIAware, MyPage {
     private val handleItemClick = OnItemClickListener { adapter, view, position ->
         val item = adapter.data[position]
         if (item != null) {
+            val nav=NavHosts.pointerNavController
             when (item) {
                 // 跳转视频
                 is SpaceInfo.ArchiveItem -> {
                     val args = VideoInfoFragment.createArguments(item.param)
-                    Navigation.findNavController(view)
-                        .navigate(VideoInfoFragment.actionId, args)
+                    nav.navigate(VideoInfoFragment.actionId, args)
                 }
                 // 跳转收藏详情
                 is SpaceInfo.FavouriteItem -> {
@@ -240,16 +264,14 @@ class UserFragment : Fragment(), DIAware, MyPage {
                         item.media_id.toString(),
                         item.name,
                     )
-                    Navigation.findNavController(view)
-                        .navigate(UserFavouriteDetailFragment.actionId, args)
+                    nav.navigate(UserFavouriteDetailFragment.actionId, args)
                 }
                 is SpaceInfo.Favourite2Item -> {
                     val args = UserFavouriteDetailFragment.createArguments(
                         item.media_id,
                         item.title,
                     )
-                    Navigation.findNavController(view)
-                        .navigate(UserFavouriteDetailFragment.actionId, args)
+                    nav.navigate(UserFavouriteDetailFragment.actionId, args)
                 }
                 is UpperChannelInfo -> {
                     val args = UserChannelDetailFragment.createArguments(
@@ -257,13 +279,11 @@ class UserFragment : Fragment(), DIAware, MyPage {
                         parent = item.mid,
                         name = item.name
                     )
-                    Navigation.findNavController(view)
-                        .navigate(UserChannelDetailFragment.actionId, args)
+                    nav.navigate(UserChannelDetailFragment.actionId, args)
                 }
                 // 跳转番剧
                 is SpaceInfo.SeasonItem -> {
-                    Navigation.findNavController(view)
-                        .navigateToCompose(BangumiDetailPage()) {
+                    nav.navigateToCompose(BangumiDetailPage()) {
                             id set item.param
                         }
                 }

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/user/UserViewModel.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/user/UserViewModel.kt
@@ -5,10 +5,8 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.navigation.findNavController
-import com.a10miaomiao.bilimiao.MainActivity
-import com.a10miaomiao.bilimiao.R
 import com.a10miaomiao.bilimiao.comm.MiaoBindingUi
+import com.a10miaomiao.bilimiao.comm.NavHosts
 import com.a10miaomiao.bilimiao.comm.apis.UserApi
 import com.a10miaomiao.bilimiao.comm.entity.MessageInfo
 import com.a10miaomiao.bilimiao.comm.entity.ResultInfo
@@ -129,8 +127,7 @@ class UserViewModel(
             setTitle("确定退出登录，喵？")
             setNegativeButton("确定退出") { dialog, which ->
                 userStore.logout()
-                val nav = (activity as? MainActivity)?.pointerNav?.navController
-                    ?: activity.findNavController(R.id.nav_host_fragment)
+                val nav = NavHosts.pointerNavController
                 nav.popBackStack()
                 PopTip.show("已退出登录了喵")
             }

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/user/archive/UserArchiveDetailFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/user/archive/UserArchiveDetailFragment.kt
@@ -1,21 +1,18 @@
 package com.a10miaomiao.bilimiao.page.user.archive
 
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
-import androidx.fragment.app.Fragment
 import androidx.lifecycle.coroutineScope
-import androidx.navigation.Navigation
-import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import cn.a10miaomiao.miao.binding.android.view._bottomPadding
 import cn.a10miaomiao.miao.binding.android.view._leftPadding
 import cn.a10miaomiao.miao.binding.android.view._rightPadding
 import com.a10miaomiao.bilimiao.R
+import com.a10miaomiao.bilimiao.comm.NavHosts
 import com.a10miaomiao.bilimiao.comm._isRefreshing
 import com.a10miaomiao.bilimiao.comm.connectUi
 import com.a10miaomiao.bilimiao.comm.diViewModel
@@ -24,12 +21,8 @@ import com.a10miaomiao.bilimiao.comm.lazyUiDi
 import com.a10miaomiao.bilimiao.comm.miaoBindingUi
 import com.a10miaomiao.bilimiao.comm.mypage.MenuItemPropInfo
 import com.a10miaomiao.bilimiao.comm.mypage.MenuKeys
-import com.a10miaomiao.bilimiao.comm.mypage.MyPage
-import com.a10miaomiao.bilimiao.comm.mypage.SearchConfigInfo
 import com.a10miaomiao.bilimiao.comm.mypage.myMenuItem
-import com.a10miaomiao.bilimiao.comm.mypage.myPageConfig
 import com.a10miaomiao.bilimiao.comm.navigation.MainNavArgs
-import com.a10miaomiao.bilimiao.comm.navigation.openSearch
 import com.a10miaomiao.bilimiao.comm.recycler.GridAutofitLayoutManager
 import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
 import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
@@ -48,7 +41,6 @@ import com.chad.library.adapter.base.listener.OnItemClickListener
 import kotlinx.coroutines.launch
 import org.kodein.di.DI
 import org.kodein.di.DIAware
-import org.kodein.di.bindSingleton
 import org.kodein.di.instance
 import splitties.dimensions.dip
 import splitties.views.backgroundColor
@@ -143,8 +135,7 @@ class UserArchiveDetailFragment : BaseResultFragment(), DIAware {
     private val handleItemClick = OnItemClickListener { adapter, view, position ->
         val item = viewModel.list.data[position]
         val args = VideoInfoFragment.createArguments(item.param)
-        Navigation.findNavController(view)
-            .navigate(VideoInfoFragment.actionId, args)
+        NavHosts.pointerNavController.navigate(VideoInfoFragment.actionId, args)
     }
 
     val itemUi = miaoBindingItemUi<ArchiveInfo> { item, index ->

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/user/archive/UserSeriesDetailFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/user/archive/UserSeriesDetailFragment.kt
@@ -1,6 +1,5 @@
 package com.a10miaomiao.bilimiao.page.user.archive
 
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -9,33 +8,24 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.coroutineScope
 import androidx.navigation.NavType
-import androidx.navigation.Navigation
 import androidx.navigation.fragment.FragmentNavigatorDestinationBuilder
-import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import cn.a10miaomiao.miao.binding.android.view._bottomPadding
 import cn.a10miaomiao.miao.binding.android.view._leftPadding
 import cn.a10miaomiao.miao.binding.android.view._rightPadding
 import cn.a10miaomiao.miao.binding.android.view._topPadding
-import com.a10miaomiao.bilimiao.R
+import com.a10miaomiao.bilimiao.comm.NavHosts
 import com.a10miaomiao.bilimiao.comm._isRefreshing
 import com.a10miaomiao.bilimiao.comm.connectUi
 import com.a10miaomiao.bilimiao.comm.diViewModel
-import com.a10miaomiao.bilimiao.comm.entity.archive.ArchiveInfo
 import com.a10miaomiao.bilimiao.comm.entity.media.MediaListV2Info
-import com.a10miaomiao.bilimiao.comm.entity.media.MediasInfo
 import com.a10miaomiao.bilimiao.comm.lazyUiDi
 import com.a10miaomiao.bilimiao.comm.miaoBindingUi
-import com.a10miaomiao.bilimiao.comm.mypage.MenuItemPropInfo
-import com.a10miaomiao.bilimiao.comm.mypage.MenuKeys
 import com.a10miaomiao.bilimiao.comm.mypage.MyPage
-import com.a10miaomiao.bilimiao.comm.mypage.SearchConfigInfo
-import com.a10miaomiao.bilimiao.comm.mypage.myMenuItem
 import com.a10miaomiao.bilimiao.comm.mypage.myPageConfig
 import com.a10miaomiao.bilimiao.comm.navigation.FragmentNavigatorBuilder
 import com.a10miaomiao.bilimiao.comm.navigation.MainNavArgs
-import com.a10miaomiao.bilimiao.comm.navigation.openSearch
 import com.a10miaomiao.bilimiao.comm.recycler.GridAutofitLayoutManager
 import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
 import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
@@ -46,8 +36,6 @@ import com.a10miaomiao.bilimiao.commponents.loading.ListState
 import com.a10miaomiao.bilimiao.commponents.loading.listStateView
 import com.a10miaomiao.bilimiao.commponents.video.videoItem
 import com.a10miaomiao.bilimiao.config.config
-import com.a10miaomiao.bilimiao.page.user.favourite.UserFavouriteDetailFragment
-import com.a10miaomiao.bilimiao.page.user.favourite.UserFavouriteDetailViewModel
 import com.a10miaomiao.bilimiao.page.video.VideoInfoFragment
 import com.a10miaomiao.bilimiao.store.WindowStore
 import com.chad.library.adapter.base.listener.OnItemClickListener
@@ -125,8 +113,7 @@ class UserSeriesDetailFragment : Fragment(), DIAware, MyPage {
     private val handleItemClick = OnItemClickListener { adapter, view, position ->
         val item = viewModel.list.data[position]
         val args = VideoInfoFragment.createArguments(item.id)
-        Navigation.findNavController(view)
-            .navigate(VideoInfoFragment.actionId, args)
+        NavHosts.pointerNavController.navigate(VideoInfoFragment.actionId, args)
     }
 
     val itemUi = miaoBindingItemUi<MediaListV2Info> { item, index ->

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/user/bangumi/MyBangumiFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/user/bangumi/MyBangumiFragment.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.navigation.Navigation
 import androidx.navigation.fragment.FragmentNavigatorDestinationBuilder
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
@@ -14,8 +13,13 @@ import cn.a10miaomiao.miao.binding.android.view._bottomPadding
 import cn.a10miaomiao.miao.binding.android.view._leftPadding
 import cn.a10miaomiao.miao.binding.android.view._rightPadding
 import cn.a10miaomiao.miao.binding.android.view._topPadding
-import com.a10miaomiao.bilimiao.comm.*
+import com.a10miaomiao.bilimiao.comm.NavHosts
+import com.a10miaomiao.bilimiao.comm._isRefreshing
+import com.a10miaomiao.bilimiao.comm.diViewModel
 import com.a10miaomiao.bilimiao.comm.entity.bangumi.MyBangumiInfo
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
+import com.a10miaomiao.bilimiao.comm.miaoStore
 import com.a10miaomiao.bilimiao.comm.mypage.MyPage
 import com.a10miaomiao.bilimiao.comm.mypage.myPageConfig
 import com.a10miaomiao.bilimiao.comm.navigation.FragmentNavigatorBuilder
@@ -24,6 +28,7 @@ import com.a10miaomiao.bilimiao.comm.recycler.GridAutofitLayoutManager
 import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
 import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
 import com.a10miaomiao.bilimiao.comm.recycler.miaoBindingItemUi
+import com.a10miaomiao.bilimiao.comm.wrapInSwipeRefreshLayout
 import com.a10miaomiao.bilimiao.commponents.bangumi.bangumiItem
 import com.a10miaomiao.bilimiao.commponents.loading.ListState
 import com.a10miaomiao.bilimiao.commponents.loading.listStateView
@@ -71,7 +76,7 @@ class MyBangumiFragment: Fragment(), DIAware, MyPage {
 
     private val handleItemClick = OnItemClickListener { adapter, view, position ->
         val item = viewModel.list.data[position]
-        Navigation.findNavController(view)
+        NavHosts.pointerNavController
             .navigateToCompose(BangumiDetailPage()) {
                 id set item.season_id
             }

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/user/bangumi/UserBangumiFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/user/bangumi/UserBangumiFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavType
-import androidx.navigation.Navigation
 import androidx.navigation.fragment.FragmentNavigatorDestinationBuilder
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
@@ -16,7 +15,12 @@ import cn.a10miaomiao.miao.binding.android.view._bottomPadding
 import cn.a10miaomiao.miao.binding.android.view._leftPadding
 import cn.a10miaomiao.miao.binding.android.view._rightPadding
 import cn.a10miaomiao.miao.binding.android.view._topPadding
-import com.a10miaomiao.bilimiao.comm.*
+import com.a10miaomiao.bilimiao.comm.NavHosts
+import com.a10miaomiao.bilimiao.comm._isRefreshing
+import com.a10miaomiao.bilimiao.comm.diViewModel
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
+import com.a10miaomiao.bilimiao.comm.miaoStore
 import com.a10miaomiao.bilimiao.comm.mypage.MyPage
 import com.a10miaomiao.bilimiao.comm.mypage.myPageConfig
 import com.a10miaomiao.bilimiao.comm.navigation.FragmentNavigatorBuilder
@@ -26,6 +30,7 @@ import com.a10miaomiao.bilimiao.comm.recycler.GridAutofitLayoutManager
 import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
 import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
 import com.a10miaomiao.bilimiao.comm.recycler.miaoBindingItemUi
+import com.a10miaomiao.bilimiao.comm.wrapInSwipeRefreshLayout
 import com.a10miaomiao.bilimiao.commponents.bangumi.bangumiItem
 import com.a10miaomiao.bilimiao.commponents.loading.ListState
 import com.a10miaomiao.bilimiao.commponents.loading.listStateView
@@ -89,7 +94,7 @@ class UserBangumiFragment : Fragment(), DIAware, MyPage {
 
     private val handleItemClick = OnItemClickListener { adapter, view, position ->
         val item = viewModel.list.data[position]
-        Navigation.findNavController(view)
+        NavHosts.pointerNavController
             .navigateToCompose(BangumiDetailPage()) {
                 id set item.param
             }

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/user/favourite/UserFavouriteDetailFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/user/favourite/UserFavouriteDetailFragment.kt
@@ -7,10 +7,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.coroutineScope
 import androidx.navigation.NavType
-import androidx.navigation.Navigation
 import androidx.navigation.fragment.FragmentNavigatorDestinationBuilder
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
@@ -19,10 +17,14 @@ import cn.a10miaomiao.miao.binding.android.view._bottomPadding
 import cn.a10miaomiao.miao.binding.android.view._leftPadding
 import cn.a10miaomiao.miao.binding.android.view._rightPadding
 import cn.a10miaomiao.miao.binding.android.view._topPadding
-import com.a10miaomiao.bilimiao.MainNavGraph
 import com.a10miaomiao.bilimiao.R
-import com.a10miaomiao.bilimiao.comm.*
+import com.a10miaomiao.bilimiao.comm.NavHosts
+import com.a10miaomiao.bilimiao.comm._isRefreshing
+import com.a10miaomiao.bilimiao.comm.connectUi
+import com.a10miaomiao.bilimiao.comm.diViewModel
 import com.a10miaomiao.bilimiao.comm.entity.media.MediasInfo
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
 import com.a10miaomiao.bilimiao.comm.mypage.MenuItemPropInfo
 import com.a10miaomiao.bilimiao.comm.mypage.MenuKeys
 import com.a10miaomiao.bilimiao.comm.mypage.MyPage
@@ -37,11 +39,11 @@ import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
 import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
 import com.a10miaomiao.bilimiao.comm.recycler.miaoBindingItemUi
 import com.a10miaomiao.bilimiao.comm.utils.NumberUtil
+import com.a10miaomiao.bilimiao.comm.wrapInSwipeRefreshLayout
 import com.a10miaomiao.bilimiao.commponents.loading.ListState
 import com.a10miaomiao.bilimiao.commponents.loading.listStateView
 import com.a10miaomiao.bilimiao.commponents.video.videoItem
 import com.a10miaomiao.bilimiao.config.config
-import com.a10miaomiao.bilimiao.page.user.HistoryFragment
 import com.a10miaomiao.bilimiao.page.video.VideoInfoFragment
 import com.a10miaomiao.bilimiao.store.WindowStore
 import com.chad.library.adapter.base.listener.OnItemClickListener
@@ -163,8 +165,7 @@ class UserFavouriteDetailFragment : Fragment(), DIAware, MyPage {
     private val handleItemClick = OnItemClickListener { adapter, view, position ->
         val item = viewModel.list.data[position]
         val args = VideoInfoFragment.createArguments(item.id)
-        Navigation.findNavController(view)
-            .navigate(VideoInfoFragment.actionId, args)
+        NavHosts.pointerNavController.navigate(VideoInfoFragment.actionId, args)
     }
 
     val itemUi = miaoBindingItemUi<MediasInfo> { item, index ->

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/video/VideoAddFavoriteFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/video/VideoAddFavoriteFragment.kt
@@ -14,21 +14,31 @@ import androidx.navigation.Navigation
 import androidx.navigation.fragment.FragmentNavigatorDestinationBuilder
 import androidx.navigation.fragment.NavHostFragment
 import androidx.recyclerview.widget.LinearLayoutManager
-import cn.a10miaomiao.miao.binding.android.view.*
+import cn.a10miaomiao.miao.binding.android.view._bottomPadding
+import cn.a10miaomiao.miao.binding.android.view._leftPadding
+import cn.a10miaomiao.miao.binding.android.view._rightPadding
+import cn.a10miaomiao.miao.binding.android.view._show
+import cn.a10miaomiao.miao.binding.android.view._tag
+import cn.a10miaomiao.miao.binding.android.view._topPadding
 import cn.a10miaomiao.miao.binding.android.widget._isChecked
 import cn.a10miaomiao.miao.binding.android.widget._text
-import com.a10miaomiao.bilimiao.MainActivity
 import com.a10miaomiao.bilimiao.R
-import com.a10miaomiao.bilimiao.comm.*
+import com.a10miaomiao.bilimiao.comm.NavHosts
+import com.a10miaomiao.bilimiao.comm.connectUi
+import com.a10miaomiao.bilimiao.comm.diViewModel
 import com.a10miaomiao.bilimiao.comm.entity.media.MediaListInfo
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
 import com.a10miaomiao.bilimiao.comm.mypage.MyPage
 import com.a10miaomiao.bilimiao.comm.mypage.myPageConfig
 import com.a10miaomiao.bilimiao.comm.navigation.FragmentNavigatorBuilder
 import com.a10miaomiao.bilimiao.comm.navigation.MainNavArgs
+import com.a10miaomiao.bilimiao.comm.progressBar
 import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
 import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
 import com.a10miaomiao.bilimiao.comm.recycler.footerViews
 import com.a10miaomiao.bilimiao.comm.recycler.miaoBindingItemUi
+import com.a10miaomiao.bilimiao.comm.views
 import com.a10miaomiao.bilimiao.config.ViewStyle
 import com.a10miaomiao.bilimiao.config.config
 import com.a10miaomiao.bilimiao.store.WindowStore
@@ -38,7 +48,15 @@ import org.kodein.di.DIAware
 import org.kodein.di.instance
 import splitties.dimensions.dip
 import splitties.toast.toast
-import splitties.views.dsl.core.*
+import splitties.views.dsl.core.checkBox
+import splitties.views.dsl.core.frameLayout
+import splitties.views.dsl.core.horizontalLayout
+import splitties.views.dsl.core.horizontalMargin
+import splitties.views.dsl.core.lParams
+import splitties.views.dsl.core.matchParent
+import splitties.views.dsl.core.textView
+import splitties.views.dsl.core.verticalLayout
+import splitties.views.dsl.core.wrapContent
 import splitties.views.dsl.recyclerview.recyclerView
 import splitties.views.horizontalPadding
 import splitties.views.padding
@@ -101,7 +119,7 @@ class VideoAddFavoriteFragment : Fragment(), DIAware, MyPage {
         val delIds = viewModel.list
             .filter { it.fav_state == 1 && !(viewModel.selectedMap[it.id] ?: true) }
             .map { it.id }
-        val navHostFragment = (activity as? MainActivity)?.currentNav
+        val navHostFragment = NavHosts.getCurrentHostFrag()
             ?: requireActivity().supportFragmentManager
                 .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
         val fragment = navHostFragment.childFragmentManager.primaryNavigationFragment

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/video/VideoCoinFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/video/VideoCoinFragment.kt
@@ -11,21 +11,27 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.coroutineScope
 import androidx.navigation.NavType
 import androidx.navigation.Navigation
-import androidx.navigation.findNavController
 import androidx.navigation.fragment.FragmentNavigatorDestinationBuilder
 import androidx.navigation.fragment.NavHostFragment
-import cn.a10miaomiao.miao.binding.android.view.*
+import cn.a10miaomiao.miao.binding.android.view._bottomPadding
+import cn.a10miaomiao.miao.binding.android.view._leftPadding
+import cn.a10miaomiao.miao.binding.android.view._rightPadding
+import cn.a10miaomiao.miao.binding.android.view._show
+import cn.a10miaomiao.miao.binding.android.view._topPadding
 import cn.a10miaomiao.miao.binding.android.widget._imageResource
 import cn.a10miaomiao.miao.binding.android.widget._text
 import cn.a10miaomiao.miao.binding.miaoEffect
-import com.a10miaomiao.bilimiao.MainActivity
-import com.a10miaomiao.bilimiao.MainNavGraph
 import com.a10miaomiao.bilimiao.R
-import com.a10miaomiao.bilimiao.comm.*
+import com.a10miaomiao.bilimiao.comm.MiaoUI
+import com.a10miaomiao.bilimiao.comm.NavHosts
+import com.a10miaomiao.bilimiao.comm.connectUi
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
 import com.a10miaomiao.bilimiao.comm.mypage.MyPage
 import com.a10miaomiao.bilimiao.comm.mypage.myPageConfig
 import com.a10miaomiao.bilimiao.comm.navigation.FragmentNavigatorBuilder
 import com.a10miaomiao.bilimiao.comm.navigation.MainNavArgs
+import com.a10miaomiao.bilimiao.comm.views
 import com.a10miaomiao.bilimiao.config.ViewStyle
 import com.a10miaomiao.bilimiao.config.config
 import com.a10miaomiao.bilimiao.store.WindowStore
@@ -34,7 +40,16 @@ import org.kodein.di.DI
 import org.kodein.di.DIAware
 import org.kodein.di.instance
 import splitties.dimensions.dip
-import splitties.views.dsl.core.*
+import splitties.views.dsl.core.frameLayout
+import splitties.views.dsl.core.horizontalLayout
+import splitties.views.dsl.core.horizontalMargin
+import splitties.views.dsl.core.imageView
+import splitties.views.dsl.core.lParams
+import splitties.views.dsl.core.margin
+import splitties.views.dsl.core.matchParent
+import splitties.views.dsl.core.textView
+import splitties.views.dsl.core.verticalLayout
+import splitties.views.dsl.core.wrapContent
 
 class VideoCoinFragment : Fragment(), DIAware, MyPage {
 
@@ -86,7 +101,7 @@ class VideoCoinFragment : Fragment(), DIAware, MyPage {
     }
 
     val handleConfirmClick = View.OnClickListener {
-        val navHostFragment = (activity as? MainActivity)?.currentNav
+        val navHostFragment = NavHosts.getCurrentHostFrag()
             ?: requireActivity().supportFragmentManager
                 .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
         val fragment = navHostFragment.childFragmentManager.primaryNavigationFragment

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/video/VideoInfoFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/video/VideoInfoFragment.kt
@@ -11,10 +11,10 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
-import androidx.navigation.*
+import androidx.navigation.NavType
+import androidx.navigation.Navigation
 import androidx.navigation.fragment.FragmentNavigatorDestinationBuilder
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
@@ -22,23 +22,34 @@ import androidx.recyclerview.widget.GridLayoutManager.SpanSizeLookup
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import cn.a10miaomiao.bilimiao.cover.CoverActivity
-import cn.a10miaomiao.miao.binding.android.view.*
+import cn.a10miaomiao.miao.binding.android.view._isEnabled
+import cn.a10miaomiao.miao.binding.android.view._leftPadding
+import cn.a10miaomiao.miao.binding.android.view._rightPadding
+import cn.a10miaomiao.miao.binding.android.view._show
+import cn.a10miaomiao.miao.binding.android.view._topPadding
 import cn.a10miaomiao.miao.binding.android.widget._text
 import cn.a10miaomiao.miao.binding.android.widget._textColor
 import cn.a10miaomiao.miao.binding.android.widget._textColorResource
 import cn.a10miaomiao.miao.binding.miaoEffect
 import cn.a10miaomiao.miao.binding.miaoMemo
-import com.a10miaomiao.bilimiao.MainActivity
 import com.a10miaomiao.bilimiao.R
-import com.a10miaomiao.bilimiao.comm.*
+import com.a10miaomiao.bilimiao.comm.BiliNavigation
+import com.a10miaomiao.bilimiao.comm.MiaoUI
+import com.a10miaomiao.bilimiao.comm.NavHosts
+import com.a10miaomiao.bilimiao.comm._isRefreshing
+import com.a10miaomiao.bilimiao.comm._network
+import com.a10miaomiao.bilimiao.comm.connectStore
 import com.a10miaomiao.bilimiao.comm.delegate.player.BasePlayerDelegate
 import com.a10miaomiao.bilimiao.comm.delegate.player.VideoPlayerSource
+import com.a10miaomiao.bilimiao.comm.diViewModel
 import com.a10miaomiao.bilimiao.comm.entity.video.UgcEpisodeInfo
 import com.a10miaomiao.bilimiao.comm.entity.video.UgcSectionInfo
 import com.a10miaomiao.bilimiao.comm.entity.video.VideoPageInfo
 import com.a10miaomiao.bilimiao.comm.entity.video.VideoRelateInfo
 import com.a10miaomiao.bilimiao.comm.entity.video.VideoStaffInfo
 import com.a10miaomiao.bilimiao.comm.entity.video.VideoTagInfo
+import com.a10miaomiao.bilimiao.comm.lazyUiDi
+import com.a10miaomiao.bilimiao.comm.miaoBindingUi
 import com.a10miaomiao.bilimiao.comm.mypage.MenuItemPropInfo
 import com.a10miaomiao.bilimiao.comm.mypage.MenuKeys
 import com.a10miaomiao.bilimiao.comm.mypage.MyPage
@@ -46,12 +57,20 @@ import com.a10miaomiao.bilimiao.comm.mypage.myMenuItem
 import com.a10miaomiao.bilimiao.comm.mypage.myPageConfig
 import com.a10miaomiao.bilimiao.comm.navigation.FragmentNavigatorBuilder
 import com.a10miaomiao.bilimiao.comm.navigation.MainNavArgs
-import com.a10miaomiao.bilimiao.comm.recycler.*
+import com.a10miaomiao.bilimiao.comm.recycler.GridAutofitLayoutManager
+import com.a10miaomiao.bilimiao.comm.recycler._miaoAdapter
+import com.a10miaomiao.bilimiao.comm.recycler._miaoLayoutManage
+import com.a10miaomiao.bilimiao.comm.recycler._miaoMultiAdapter
+import com.a10miaomiao.bilimiao.comm.recycler.footerViews
+import com.a10miaomiao.bilimiao.comm.recycler.headerViews
+import com.a10miaomiao.bilimiao.comm.recycler.lParams
+import com.a10miaomiao.bilimiao.comm.recycler.miaoBindingItemUi
 import com.a10miaomiao.bilimiao.comm.store.PlayerStore
 import com.a10miaomiao.bilimiao.comm.store.UserStore
 import com.a10miaomiao.bilimiao.comm.utils.BiliUrlMatcher
-import com.a10miaomiao.bilimiao.comm.utils.DebugMiao
 import com.a10miaomiao.bilimiao.comm.utils.NumberUtil
+import com.a10miaomiao.bilimiao.comm.views
+import com.a10miaomiao.bilimiao.comm.wrapInSwipeRefreshLayout
 import com.a10miaomiao.bilimiao.commponents.video.videoItem
 import com.a10miaomiao.bilimiao.config.ViewStyle
 import com.a10miaomiao.bilimiao.config.config
@@ -65,21 +84,33 @@ import com.a10miaomiao.bilimiao.widget.expandableTextView
 import com.a10miaomiao.bilimiao.widget.expandabletext.ExpandableTextView
 import com.a10miaomiao.bilimiao.widget.expandabletext.app.LinkType
 import com.a10miaomiao.bilimiao.widget.rcImageView
-import com.chad.library.adapter.base.delegate.BaseMultiTypeDelegate
 import com.chad.library.adapter.base.listener.OnItemClickListener
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexWrap
 import com.google.android.flexbox.FlexboxLayoutManager
 import com.kongzue.dialogx.dialogs.PopTip
-import net.mikaelzero.mojito.ext.mojito
 import org.kodein.di.DI
 import org.kodein.di.DIAware
 import org.kodein.di.instance
 import splitties.dimensions.dip
 import splitties.experimental.InternalSplittiesApi
-import splitties.views.*
-import splitties.views.dsl.core.*
+import splitties.views.backgroundColor
+import splitties.views.bottomPadding
+import splitties.views.dsl.core.frameLayout
+import splitties.views.dsl.core.horizontalLayout
+import splitties.views.dsl.core.imageView
+import splitties.views.dsl.core.lParams
+import splitties.views.dsl.core.matchParent
+import splitties.views.dsl.core.textView
+import splitties.views.dsl.core.verticalLayout
+import splitties.views.dsl.core.view
+import splitties.views.dsl.core.wrapContent
 import splitties.views.dsl.recyclerview.recyclerView
+import splitties.views.horizontalPadding
+import splitties.views.imageResource
+import splitties.views.padding
+import splitties.views.topPadding
+import splitties.views.verticalPadding
 
 
 class VideoInfoFragment : Fragment(), DIAware, MyPage {
@@ -211,8 +242,7 @@ class VideoInfoFragment : Fragment(), DIAware, MyPage {
             1 -> {
                 // 评论
                 if (info != null) {
-                    val nav = (activity as? MainActivity)?.pointerNav?.navController
-                        ?: requireActivity().findNavController(R.id.nav_host_fragment)
+                    val nav = NavHosts.pointerNavController
                     val args = VideoCommentListFragment.createArguments(
                         info.aid,
                         info.title,

--- a/app/src/main/java/com/a10miaomiao/bilimiao/page/web/WebFragment.kt
+++ b/app/src/main/java/com/a10miaomiao/bilimiao/page/web/WebFragment.kt
@@ -141,7 +141,7 @@ class WebFragment : Fragment(), DIAware, MyPage {
     private val mWebViewClient = object : WebViewClient() {
         override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
             var url = request.url.toString()
-            val re = BiliNavigation.navigationTo(view, url)
+            val re = BiliNavigation.navigationTo(NavHosts.pointerNavController, url)
             if (re) {
                 return true
             }

--- a/bilimiao-comm/build.gradle.kts
+++ b/bilimiao-comm/build.gradle.kts
@@ -1,5 +1,6 @@
-import com.google.protobuf.gradle.*
-import cn.a10miaomiao.bilimiao.build.*
+import cn.a10miaomiao.bilimiao.build.Libraries
+import com.google.protobuf.gradle.id
+import com.google.protobuf.gradle.proto
 
 plugins {
     id("com.android.library")
@@ -105,4 +106,6 @@ dependencies {
     testImplementation(Libraries.junit)
     androidTestImplementation(Libraries.androidxJunit)
     androidTestImplementation(Libraries.espresso)
+
+    implementation(Libraries.navigationFragment)
 }

--- a/bilimiao-comm/src/main/java/com/a10miaomiao/bilimiao/comm/NavHosts.kt
+++ b/bilimiao-comm/src/main/java/com/a10miaomiao/bilimiao/comm/NavHosts.kt
@@ -1,0 +1,39 @@
+package com.a10miaomiao.bilimiao.comm
+
+import androidx.navigation.NavController
+import androidx.navigation.fragment.NavHostFragment
+
+object NavHosts {
+    var getMainHostFrag:()->NavHostFragment?={ null } //主内容
+    var getSubHostFrag:()->NavHostFragment?={ null }  //副内容
+    var getCurrentHostFrag:()->NavHostFragment?={ null } //焦点所在处
+    var getAnotherHostFrag:()->NavHostFragment?={ null } //非焦点处
+    var getPointerHostFrag:()->NavHostFragment?={ null } //跟随指示器
+    var getBottomSheetHostFrag:()->NavHostFragment?={ null } //底部弹出页面
+
+
+    val mainNavController
+        get() = getMainHostFrag()!!.navController
+    val subNavController
+        get() = getSubHostFrag()!!.navController
+    val currentNavController
+        get() = getCurrentHostFrag()!!.navController
+    val anotherNavController
+        get() = getAnotherHostFrag()!!.navController
+    val pointerNavController
+        get() = getPointerHostFrag()!!.navController
+    val bottomSheetNavController
+        get() = getBottomSheetHostFrag()!!.navController
+
+    fun getNavHostFragment(controller:NavController):NavHostFragment?{
+        return if(controller === mainNavController){
+            getMainHostFrag()
+        } else if (controller === subNavController){
+            getSubHostFrag()
+        } else if (controller === bottomSheetNavController){
+            getBottomSheetHostFrag()
+        } else {
+            null
+        }
+    }
+}

--- a/bilimiao-compose/src/main/java/cn/a10miaomiao/bilimiao/compose/pages/bangumi/BangumiDetailPage.kt
+++ b/bilimiao-compose/src/main/java/cn/a10miaomiao/bilimiao/compose/pages/bangumi/BangumiDetailPage.kt
@@ -4,36 +4,44 @@ import android.content.Intent
 import android.net.Uri
 import android.view.View
 import androidx.compose.animation.AnimatedContentScope
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.modifier.modifierLocalConsumer
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.core.graphics.toColorInt
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavBackStackEntry
-import androidx.navigation.NavHostController
-import androidx.navigation.fragment.findNavController
 import cn.a10miaomiao.bilimiao.compose.base.ComposePage
 import cn.a10miaomiao.bilimiao.compose.base.stringPageArg
 import cn.a10miaomiao.bilimiao.compose.comm.defaultNavOptions
@@ -46,22 +54,23 @@ import cn.a10miaomiao.bilimiao.compose.commponents.layout.DoubleColumnAutofitLay
 import cn.a10miaomiao.bilimiao.compose.commponents.layout.chain_scrollable.rememberChainScrollableLayoutState
 import cn.a10miaomiao.bilimiao.compose.pages.bangumi.commponents.BangumiEpisodeItem
 import cn.a10miaomiao.bilimiao.compose.pages.bangumi.popup_menu.BangumiMorePopupMenu
+import com.a10miaomiao.bilimiao.comm.NavHosts
 import com.a10miaomiao.bilimiao.comm.delegate.player.BangumiPlayerSource
 import com.a10miaomiao.bilimiao.comm.delegate.player.BasePlayerDelegate
 import com.a10miaomiao.bilimiao.comm.entity.ResultInfo
 import com.a10miaomiao.bilimiao.comm.entity.ResultInfo2
-import com.a10miaomiao.bilimiao.comm.entity.bangumi.*
+import com.a10miaomiao.bilimiao.comm.entity.bangumi.EpisodeInfo
+import com.a10miaomiao.bilimiao.comm.entity.bangumi.SeasonInfo
+import com.a10miaomiao.bilimiao.comm.entity.bangumi.SeasonSectionInfo
+import com.a10miaomiao.bilimiao.comm.entity.bangumi.SeasonV2Info
 import com.a10miaomiao.bilimiao.comm.entity.comm.ToastInfo
 import com.a10miaomiao.bilimiao.comm.mypage.MenuItemPropInfo
 import com.a10miaomiao.bilimiao.comm.mypage.MenuKeys
-import com.a10miaomiao.bilimiao.comm.mypage.MyPage
 import com.a10miaomiao.bilimiao.comm.mypage.myMenuItem
 import com.a10miaomiao.bilimiao.comm.network.BiliApiService
 import com.a10miaomiao.bilimiao.comm.network.MiaoHttp
 import com.a10miaomiao.bilimiao.comm.network.MiaoHttp.Companion.gson
 import com.a10miaomiao.bilimiao.comm.store.PlayerStore
-import com.a10miaomiao.bilimiao.comm.utils.DebugMiao
-import com.a10miaomiao.bilimiao.comm.utils.NumberUtil
 import com.a10miaomiao.bilimiao.comm.utils.UrlUtil
 import com.a10miaomiao.bilimiao.store.WindowStore
 import com.google.gson.JsonObject
@@ -69,7 +78,6 @@ import com.kongzue.dialogx.dialogs.PopTip
 import com.skydoves.landscapist.glide.GlideImage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.kodein.di.DI
@@ -270,7 +278,7 @@ internal class BangumiDetailPageViewModel(
         val cover = Uri.encode(item.cover)
         val name = Uri.encode(detailInfo.value?.season_title ?: "")
         val uri = Uri.parse("bilimiao://video/$id/comment?title=$title&cover=$cover&name=$name")
-        fragment.findNavController().navigate(uri, defaultNavOptions)
+        NavHosts.pointerNavController?.navigate(uri, defaultNavOptions)
     }
 
     fun shareEpisode(item: EpisodeInfo) {


### PR DESCRIPTION
用单例记录了navhost，方便给页面设计跳转的位置
把一些跳转改成了跟随指示器的，比如推荐页视频，收藏夹视频，番剧评论等

androidstudio自动优化了很多import