### PR TITLE
Disable WebView file access in H5LoginPage and WebPage

### DIFF
--- a/bilimiao-compose/src/main/java/cn/a10miaomiao/bilimiao/compose/pages/auth/H5LoginPage.kt
+++ b/bilimiao-compose/src/main/java/cn/a10miaomiao/bilimiao/compose/pages/auth/H5LoginPage.kt
@@ -128,7 +128,12 @@ private class H5LoginPageViewModel(
             }
             userAgentString = defaultUserAgentString
             allowContentAccess = true
-            allowFileAccess = true
+            // The H5 login WebView only loads https Bilibili passport URLs
+            // (see loadUrl(startUrl) below). It does not need file://
+            // access, and the _BiliJsBridge interface attached in
+            // setBiliAppWebView would be reachable from a same-origin
+            // file:// page if a stray file URL ever landed here.
+            allowFileAccess = false
             cacheMode = WebSettings.LOAD_DEFAULT
             databaseEnabled = true
             domStorageEnabled = true

--- a/bilimiao-compose/src/main/java/cn/a10miaomiao/bilimiao/compose/pages/web/WebPage.kt
+++ b/bilimiao-compose/src/main/java/cn/a10miaomiao/bilimiao/compose/pages/web/WebPage.kt
@@ -103,7 +103,12 @@ private class WebPageViewModel(
             }
             userAgentString = "$defaultUserAgentString $userAgent"
             allowContentAccess = true
-            allowFileAccess = true
+            // WebPage is opened with startUrl, which is always an http or
+            // https URL routed through BilibiliNavigation. It does not
+            // need file:// access, and the _BiliJsBridge interface
+            // attached below would be reachable from a same-origin
+            // file:// page if a stray file URL ever landed here.
+            allowFileAccess = false
             cacheMode = WebSettings.LOAD_DEFAULT
             databaseEnabled = true
             domStorageEnabled = true


### PR DESCRIPTION
Closes #298.

Both `H5LoginPage.initWebView` and `WebPage.initWebView` construct their WebView with `settings.allowFileAccess = true` and then attach the `_BiliJsBridge` JS interface to the same WebView:

```kotlin
view.settings.apply {
    ...
    allowFileAccess = true
    ...
}
...
view.addJavascriptInterface(biliJsBridge, "_BiliJsBridge")
view.loadUrl(startUrl)
```

`H5LoginPage` loads the Bilibili passport login URL (https). `WebPage` loads `startUrl`, which is always an http or https URL routed through `BilibiliNavigation`. Neither code path legitimately needs `file://` access.

### Change

Flip `allowFileAccess` to `false` in both files. With `_BiliJsBridge` attached, leaving the flag on is more attack surface than the loaded site asks for, since a stray `file://` load would otherwise be able to reach the bridge from a same-origin `file://` context.

`file:///android_asset/*` loads remain permitted on every supported Android version regardless of this flag, so this does not break any bundled-asset path.