### PR TITLE
fix: clamp negative insets in ContentInsets.toPaddingValues

### DIFF
--- a/bilimiao-compose/src/commonMain/kotlin/cn/a10miaomiao/bilimiao/compose/common/ContentInsets.kt
+++ b/bilimiao-compose/src/commonMain/kotlin/cn/a10miaomiao/bilimiao/compose/common/ContentInsets.kt
@@ -59,10 +59,10 @@ fun ContentInsets.toPaddingValues(
 ): PaddingValues {
     return remember(this, left, right, top, bottom) {
         PaddingValues.Absolute(
-            left = left ?: this.left,
-            right = right ?: this.right,
-            top = top ?: this.top,
-            bottom = bottom ?: this.bottom,
+            left = max(left ?: this.left, 0.dp),
+            right = max(right ?: this.right, 0.dp),
+            top = max(top ?: this.top, 0.dp),
+            bottom = max(bottom ?: this.bottom, 0.dp),
         )
     }
 }


### PR DESCRIPTION
## Problem

The app crashes with `IllegalArgumentException: Padding must be non-negative` when the screen is rotated (or any configuration change occurs) while certain pages are open. The crash is caught by the built-in crash handler, which then drops the user into the log viewer screen.

### Root cause

`ContentInsets.toPaddingValues()` feeds the raw insets directly into `PaddingValues.Absolute(...)`:

```kotlin
PaddingValues.Absolute(
    left = left ?: this.left,
    right = right ?: this.right,
    top = top ?: this.top,
    bottom = bottom ?: this.bottom,
)
```

`PaddingValues.Absolute` validates its constructor arguments and throws when any value is negative. During a configuration change the window insets can briefly become negative while the system transitions between orientations, so any page that calls `toPaddingValues()` (e.g. `VideoDetailPage`, `BangumiDetailPage`, dynamic pages, reply list pages) crashes on rotation.

Note that `addPaddingValues()` in the same file already guards against this with `max(value, 0.dp)` — `toPaddingValues()` was simply missing the same guard.

## Fix

Clamp every side to `0.dp` with `max()`, matching the existing `addPaddingValues()` implementation:

```kotlin
PaddingValues.Absolute(
    left = max(left ?: this.left, 0.dp),
    right = max(right ?: this.right, 0.dp),
    top = max(top ?: this.top, 0.dp),
    bottom = max(bottom ?: this.bottom, 0.dp),
)
```

## Reproduction

1. Open a video detail page (or any page using `toPaddingValues`).
2. Rotate the device.
3. Crash: `java.lang.IllegalArgumentException: Padding must be non-negative` at `PaddingValues$Absolute.<init>`.

## Verification

Verified on a real device (Android 5.1, bilimiao 2.4.8.1): with the fix applied, rotating the screen across multiple pages no longer crashes. The same fix is applied here on `master` for `ContentInsets` (the 2.4.8.1 release used `WindowStore.Insets`, which was refactored to `ContentInsets` upstream).
